### PR TITLE
Fix CI/Workflow Setup Guide, Remove Deprecated `materialx.emoji` Extension and Improve Linux Local Tesitng Info

### DIFF
--- a/Pages/contributing.md
+++ b/Pages/contributing.md
@@ -46,18 +46,48 @@ Here's a quick guide of how you could do it from your `command prompt` (cmd).
 1. Install Python 3
 
     If you have `winget` installed, or Windows 11, you can do this from the command prompt.
-    ```bash
-    winget install Python.Python.3
-    ```
+
+    === "Windows (winget)"
+
+        ```bash
+        winget install Python.Python.3
+        ```
+
+    === "Archlinux"
+
+        ```
+        pacman -S python-pip # you should already have Python
+        ```
 
     Otherwise download Python 3 from the official website or package manager.
 
 2. Install Material for MkDocs and Plugins (Python package)
-    ```bash
-    # Restart your command prompt before running this command.
-    pip install mkdocs-material
-    pip install mkdocs-redirects
-    ```
+
+
+    === "Windows/OSX"
+
+        ```bash
+        # Restart your command prompt before running this command.
+        pip install mkdocs-material
+        pip install mkdocs-redirects
+        ```
+
+    === "Linux"
+
+        On Linux, there is a chance that `python` might be a core part of your OS, meaning
+        that you ideally shouldn't touch the system installation.
+
+        Use virtual environments instead.
+
+        ```bash
+        python -m venv mkdocs # Create the environment
+        source ~/mkdocs/bin/activate # Enter the environment
+
+        pip install mkdocs-material
+        pip install mkdocs-redirects
+        ```
+
+        Make sure you enter the environment before any time you run mkdocs.
 
 3. Open a command prompt in the folder containing `mkdocs.yml`. and run the site locally.
     ```bash

--- a/Pages/index.md
+++ b/Pages/index.md
@@ -60,8 +60,8 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 theme:
   name: material
@@ -80,45 +80,32 @@ nav:
 - Add a GitHub Actions workload in `.github/workflows/DeployMkDocs.yml`.
 
 ```yaml
-name: DeployMkDocs
+name: MkDocs Build and Deploy
 
-# Controls when the action will run. 
 on:
-  # Triggers the workflow on push on the master branch
+  workflow_dispatch:
   push:
     branches: [ main ]
+    paths:
+      - "mkdocs.yml"
+      - "docs/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "mkdocs.yml"
+      - "docs/**"
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+  build-and-deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/mkdocs-build-and-deploy.yaml@main
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout Branch
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      # Deploy MkDocs
-      - name: Deploy MkDocs
-        # You may pin to the exact commit or the version.
-        # uses: mhausenblas/mkdocs-deploy-gh-pages@66340182cb2a1a63f8a3783e3e2146b7d151a0bb
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REQUIREMENTS: ./docs/requirements.txt
 ```
 
-- Push to GitHub, this should produce a GitHub Pages site.  
-- Go to `Settings -> Pages` in your repo and select `gh-pages` branch to enable GitHub pages. 
+- Push to GitHub, this should produce a GitHub Pages site. 
 
 Your page should then be live.
 


### PR DESCRIPTION
Fixes:

- #1 
- #2 
- #3 

(Can't assign 'developers' as reviewers, so I just picked an unlucky victim >x<)

In any case, these are backports from my fork of the repo.